### PR TITLE
Dont print diff when config is changeing

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,10 +7,11 @@ class nslcd::config inherits nslcd
   file
   {
     $nslcd::config:
-      ensure  => file,
-      owner   => $nslcd::config_user,
-      group   => $nslcd::config_group,
-      mode    => $nslcd::config_mode,
-      content => template('nslcd/nslcd.erb'),
+      ensure    => file,
+      owner     => $nslcd::config_user,
+      group     => $nslcd::config_group,
+      mode      => $nslcd::config_mode,
+      show_diff => false
+      content   => template('nslcd/nslcd.erb'),
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class nslcd::config inherits nslcd
       owner     => $nslcd::config_user,
       group     => $nslcd::config_group,
       mode      => $nslcd::config_mode,
-      show_diff => false
+      show_diff => false,
       content   => template('nslcd/nslcd.erb'),
   }
 }


### PR DESCRIPTION
Greetings,

we are using the nslcd::ldap_bindpw and when changing the bindpw it is printed in the default output and also writting into the report in plaintext.
To prevent this just use show_diff => false ( default true ) in the config file resource.