### PR TITLE
update stdlib dependencies and supported Debian versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 8.1.0"
+      "version_requirement": ">= 4.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -20,7 +20,8 @@
         "8",
         "9",
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
Hi,

i am using this module just fine with the stdlib 9.3 and Debian 12 so i thought i just send you this pull request with the updated dependencies and supported Debian Versions.

My CICD is complaining otherwise :)

br