### PR TITLE
Replace legacy "osfamily" fact with structured fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 #
 class nslcd::params
 {
-  case $::osfamily
+  case $facts['os']['family']
   {
     'Debian':
     {
@@ -22,7 +22,7 @@ class nslcd::params
     }
     default:
     {
-      fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
+      fail("The ${module_name} module is not supported on an $facts['os']['family'] based system.")
     }
   }
 }


### PR DESCRIPTION
Hi,

the fact "osfamily" is, at least since puppet 5.5, marked as a legacy fact. 

I replaced it with the "new" structured fact.

This should be backwards compatible to at least 5.5 ( https://www.puppet.com/docs/puppet/5.5/core_facts#os )

br